### PR TITLE
Modify Heading font size

### DIFF
--- a/assets/src/styles/blocks/core-overrides/_media-text.scss
+++ b/assets/src/styles/blocks/core-overrides/_media-text.scss
@@ -49,6 +49,11 @@
     &:not(.has-media-on-the-right) .wp-block-media-text__content {
       padding-inline-start: $sp-3;
     }
+
+    // Applied only to medium or large screens
+    .wp-block-heading {
+      font-size: 3rem;
+    }
   }
 
   &.alignfull.has-media-on-the-right .wp-block-media-text__content {


### PR DESCRIPTION
In this case I first inspect if the heading is part of a block or just an isolated heading. If so, then inspect which block is that one. After that I can look for its assigned stylesheet.

I noticed that the block is the media-block and it has an assigned stylesheet `/assets/src/styles/blocks/core-overrides/_media-text.scss`.

After that I analyze if the new font size can be applied in all screens or just only in `desktop`. So, I have different approaches here. 

- If it is going to be applied to all @media, then:
```css
.wp-block-media-text .wp-heading {
  font-size: 3rem;
}
```

- If it is going to be applied only to large screens, then:
```css
@media large-and-up {
  .wp-block-media-text .wp-block-heading {
    font-size: 3rem;
  }
}
```

**Of course there are a bunch of ways to change the font size. Also more specificity and use more class names.**
